### PR TITLE
Fixed leapyear checker in UBEM.py

### DIFF
--- a/UBEM.py
+++ b/UBEM.py
@@ -70,7 +70,7 @@ def leap_year(year):
     """
     Checks if the given year is leap year
     """
-    if ((year % 400 == 0) or (year % 100 == 0) and (year % 4 ==0)):
+    if ((year % 400 == 0) or (year % 100 != 0) and (year % 4 ==0)):
         return 1
     else:
         return 0


### PR DESCRIPTION
The leap-year checker logic was wrong. It would fail to identify leap years like 2004 (failed both the or statements). Fixed it by changing the condition.